### PR TITLE
DODO-34: Integrate SuperToken on FE as demo

### DIFF
--- a/app/client.tsx
+++ b/app/client.tsx
@@ -3,12 +3,26 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { StartClient } from '@tanstack/start';
 import { createRouter } from './router';
+import { superTokenConfig } from './config/superToken';
+import SuperTokens, { SuperTokensWrapper } from 'supertokens-auth-react';
+import { canHandleRoute, getRoutingComponent } from 'supertokens-auth-react/ui';
+import { ThirdPartyPreBuiltUI } from 'supertokens-auth-react/recipe/thirdparty/prebuiltui';
+import { PasswordlessPreBuiltUI } from 'supertokens-auth-react/recipe/passwordless/prebuiltui';
+
+SuperTokens.init(superTokenConfig);
 
 const router = createRouter();
 
 const root = createRoot(document.getElementById('root')!);
 root.render(
   <StrictMode>
-    <StartClient router={router} />
+    {canHandleRoute([ThirdPartyPreBuiltUI, PasswordlessPreBuiltUI]) ? (
+      // This renders the login UI on the /auth route
+      getRoutingComponent([ThirdPartyPreBuiltUI, PasswordlessPreBuiltUI])
+    ) : (
+      <SuperTokensWrapper>
+        <StartClient router={router} />
+      </SuperTokensWrapper>
+    )}
   </StrictMode>
 );

--- a/app/config/superToken.ts
+++ b/app/config/superToken.ts
@@ -1,0 +1,29 @@
+import Passwordless from 'supertokens-auth-react/recipe/passwordless';
+import ThirdParty from 'supertokens-auth-react/recipe/thirdparty';
+import Session from 'supertokens-auth-react/recipe/session';
+
+// TODO: Config for SuperTokens should be defined as environment variables
+export const superTokenConfig = {
+  appInfo: {
+    appName: 'Dodo',
+    apiDomain: 'http://localhost:8080',
+    websiteDomain: 'http://localhost:3000',
+    apiBasePath: '/auth',
+    websiteBasePath: '/auth',
+  },
+  recipeList: [
+    Passwordless.init({
+      contactMethod: 'EMAIL',
+    }),
+    ThirdParty.init({
+      signInAndUpFeature: {
+        providers: [
+          ThirdParty.Google.init(),
+          ThirdParty.Facebook.init(),
+          ThirdParty.Apple.init(),
+        ],
+      },
+    }),
+    Session.init(),
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.453.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "supertokens-auth-react": "^0.48.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "vinxi": "^0.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      supertokens-auth-react:
+        specifier: ^0.48.0
+        version: 0.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supertokens-web-js@0.14.0)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -93,18 +96,12 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
-      postcss-lit:
-        specifier: ^1.1.1
-        version: 1.1.1(postcss@8.4.47)
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
       stylelint:
         specifier: ^16.10.0
         version: 16.10.0(typescript@5.6.3)
-      stylelint-config-standard:
-        specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.10.0(typescript@5.6.3))
       stylelint-config-tailwindcss:
         specifier: ^0.0.7
         version: 0.0.7(stylelint@16.10.0(typescript@5.6.3))(tailwindcss@3.4.14)
@@ -1709,6 +1706,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-tabs-lock@1.3.0:
+    resolution: {integrity: sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==}
+
   browserslist@4.24.0:
     resolution: {integrity: sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2670,6 +2670,9 @@ packages:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
 
+  intl-tel-input@17.0.21:
+    resolution: {integrity: sha512-TfyPxLe41QZPOf6RqBxRE2dpQ0FThB/PBD/gRbxVhGW7IuYg30QD90x/vjmEo4vkZw7j8etxpVcjIZVRcG+Otw==}
+
   ioredis@5.4.1:
     resolution: {integrity: sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==}
     engines: {node: '>=12.22.0'}
@@ -3557,11 +3560,6 @@ packages:
     peerDependencies:
       postcss: ^8.4.21
 
-  postcss-lit@1.1.1:
-    resolution: {integrity: sha512-zbOUUDmnHj9y/FINVARaSKE/gtPDpn/qT/B26NzQRFK9Z0yB3tUYnyn6PbSlNndKu3RnaTB8Q9bVO9UJwd/omg==}
-    peerDependencies:
-      postcss: ^8.3.11
-
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
@@ -3642,6 +3640,9 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  qr.js@0.0.0:
+    resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -3674,6 +3675,11 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-qr-code@2.0.15:
+    resolution: {integrity: sha512-MkZcjEXqVKqXEIMVE0mbcGgDpkfSdd8zhuzXEl9QzYeNcw8Hq2oVIzDLWuZN2PQBwM5PWjc2S31K8Q1UbcFMfw==}
+    peerDependencies:
+      react: '*'
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -4010,18 +4016,6 @@ packages:
   strip-literal@2.1.0:
     resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
-  stylelint-config-recommended@14.0.1:
-    resolution: {integrity: sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      stylelint: ^16.1.0
-
-  stylelint-config-standard@36.0.1:
-    resolution: {integrity: sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      stylelint: ^16.1.0
-
   stylelint-config-tailwindcss@0.0.7:
     resolution: {integrity: sha512-n2dCWH+0ppr0/by4EYCLWW7g5LU+l4UzUIsYS7xbVHqvm9UWa7UhltNdNiz5NmLF/FmbJR4Yd/v9DuUGvLw1Tg==}
     peerDependencies:
@@ -4037,6 +4031,23 @@ packages:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supertokens-auth-react@0.48.0:
+    resolution: {integrity: sha512-JDahnvSKahso6LbD3Oe/e2Ifxz/dg7kMVGnlt+sZbz/kNSQAKk7yaTrxrCemcNDw5IDB9etheCVrLu7ye/ndmQ==}
+    engines: {node: '>=16.0.0', npm: '>=8'}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      supertokens-web-js: ^0.14.0
+
+  supertokens-js-override@0.0.4:
+    resolution: {integrity: sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg==}
+
+  supertokens-web-js@0.14.0:
+    resolution: {integrity: sha512-p4HZ580YX9UYFfY9Sv2VzBQOilqHnNzhrmHlOc45oMxqr/vqvqf+Ih7OXS1lx6RUVmQT8TAsLlFFKIWslIkbHA==}
+
+  supertokens-website@20.1.5:
+    resolution: {integrity: sha512-2yN42BvHY41/pNIFdJTKSRW3sWZzfOY607i6cY+WWjHSAx7ppMgujyk8tKj+fiQ4MLWCk3HL6QsXZl0zLV4yEw==}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -6169,6 +6180,10 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-tabs-lock@1.3.0:
+    dependencies:
+      lodash: 4.17.21
+
   browserslist@4.24.0:
     dependencies:
       caniuse-lite: 1.0.30001669
@@ -7235,6 +7250,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+
+  intl-tel-input@17.0.21: {}
 
   ioredis@5.4.1:
     dependencies:
@@ -8347,16 +8364,6 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
-  postcss-lit@1.1.1(postcss@8.4.47):
-    dependencies:
-      '@babel/generator': 7.25.7
-      '@babel/parser': 7.25.8
-      '@babel/traverse': 7.25.7
-      lilconfig: 2.1.0
-      postcss: 8.4.47
-    transitivePeerDependencies:
-      - supports-color
-
   postcss-load-config@4.0.2(postcss@8.4.47):
     dependencies:
       lilconfig: 3.1.2
@@ -8425,6 +8432,8 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  qr.js@0.0.0: {}
+
   queue-microtask@1.2.3: {}
 
   queue-tick@1.0.1: {}
@@ -8453,6 +8462,12 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-qr-code@2.0.15(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      qr.js: 0.0.0
+      react: 18.3.1
 
   react-refresh@0.14.2: {}
 
@@ -8858,15 +8873,6 @@ snapshots:
     dependencies:
       js-tokens: 9.0.0
 
-  stylelint-config-recommended@14.0.1(stylelint@16.10.0(typescript@5.6.3)):
-    dependencies:
-      stylelint: 16.10.0(typescript@5.6.3)
-
-  stylelint-config-standard@36.0.1(stylelint@16.10.0(typescript@5.6.3)):
-    dependencies:
-      stylelint: 16.10.0(typescript@5.6.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.10.0(typescript@5.6.3))
-
   stylelint-config-tailwindcss@0.0.7(stylelint@16.10.0(typescript@5.6.3))(tailwindcss@3.4.14):
     dependencies:
       stylelint: 16.10.0(typescript@5.6.3)
@@ -8925,6 +8931,28 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
+
+  supertokens-auth-react@0.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supertokens-web-js@0.14.0):
+    dependencies:
+      intl-tel-input: 17.0.21
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-qr-code: 2.0.15(react@18.3.1)
+      supertokens-js-override: 0.0.4
+      supertokens-web-js: 0.14.0
+
+  supertokens-js-override@0.0.4: {}
+
+  supertokens-web-js@0.14.0:
+    dependencies:
+      supertokens-js-override: 0.0.4
+      supertokens-website: 20.1.5
+
+  supertokens-website@20.1.5:
+    dependencies:
+      browser-tabs-lock: 1.3.0
+      supertokens-js-override: 0.0.4
 
   supports-color@5.5.0:
     dependencies:


### PR DESCRIPTION
This PR is for demo purpose of integrating SuperToken to frontend. The integration was refered to the @tanstack/router [post](https://tanstack.com/router/latest/docs/framework/react/migrate-from-react-router) and [this example repo](https://github.com/Benanna2019/SickFitsForEveryone/blob/migrate-to-tanstack/router/React-Router/client/src/main.tsx) to fit the @tanstack/start framework.

After running the project, you can access the login page from `/auth` path.

The follow up tasks should be:

1. Customize the UI to fit our shadcn/UI theme configuration.
2. Remove the SuperToken logo.
3. Integrate with BE and create dashboard for local and STG use.